### PR TITLE
Fix Server-Rendered Styles in Docs

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -6,34 +6,35 @@ import { Header, Footer } from "formidable-landers";
 import stylesheet from "../playbook-stylesheet";
 import theme from "../playbook-theme";
 
-class App extends React.Component {
-  render() {
-    const styleRootStyles = {
-      display: "flex",
-      flexDirection: "column",
-      minHeight: "100vh"
-    };
-
-    return (
-      <StyleRoot style={styleRootStyles}>
-        <Header
-          background={theme.white}
-          linkStyles={{
-            color: theme.charcoal,
-            fontFamily: theme.serif,
-            textDecoration: "none",
-            ":hover": {
-              color: theme.red
-            }
-          }}
-        />
-        {this.props.children}
-        <Footer background={`${theme.white} url('./static/footer.jpg') no-repeat top center`} />
-        <Style rules={stylesheet} />
-      </StyleRoot>
-    );
-  }
-}
+const App = function ({children}) {
+  const styleRootStyles = {
+    display: "flex",
+    flexDirection: "column",
+    minHeight: "100vh"
+  };
+  const isBrowser = typeof window !== "undefined" && window.__STATIC_GENERATOR !== true;
+  return (
+    <StyleRoot
+      radiumConfig={isBrowser ? { userAgent: window.navigator.userAgent } : null}
+      style={styleRootStyles}
+    >
+      <Style rules={stylesheet} />
+      <Header
+        background={theme.white}
+        linkStyles={{
+          color: theme.charcoal,
+          fontFamily: theme.serif,
+          textDecoration: "none",
+          ":hover": {
+            color: theme.red
+          }
+        }}
+      />
+      {children}
+      <Footer background={`${theme.white} url('./static/footer.jpg') no-repeat top center`} />
+    </StyleRoot>
+  );
+};
 
 App.propTypes = {
   children: React.PropTypes.node.isRequired,

--- a/src/components/entry.js
+++ b/src/components/entry.js
@@ -26,6 +26,10 @@ if (typeof window !== "undefined" && window.__STATIC_GENERATOR !== true) { //esl
 
 // Exported static site renderer:
 export default (locals, callback) => {
+  global.navigator = {
+    userAgent: "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2454.85 Safari/537.36"
+  };
+
   const history = createMemoryHistory();
   const location = history.createLocation(locals.path);
   match({ routes, location }, (error, redirectLocation, renderProps) => {


### PR DESCRIPTION
This will place the `<Style>` component above the children, making global styles load first. The useragent correctly sets the prefixing for Radium serverside.

This will fix #23

cc @paulathevalley @bmathews 